### PR TITLE
fix(addon-notes): inline code markdown

### DIFF
--- a/addons/notes/src/Panel.tsx
+++ b/addons/notes/src/Panel.tsx
@@ -41,7 +41,15 @@ function read(param: Parameters | undefined): string | undefined {
   }
 }
 
-const SyntaxHighlighter = (props: any) => <SyntaxHighlighterBase bordered copyable {...props} />;
+const SyntaxHighlighter = (props: any) => {
+  // markdown-to-jsx does not add className to inline code
+  if (props.className === undefined) {
+    return <code>{props.children}</code>;
+  }
+  //className: "lang-jsx"
+  const language = props.className.split('-');
+  return <SyntaxHighlighterBase language={language[1]} bordered copyable {...props} />;
+};
 
 const defaultOptions = {
   overrides: {
@@ -105,21 +113,25 @@ export default class NotesPanel extends React.Component<Props, NotesPanelState> 
 
     // TODO: memoize
     const extraElements = Object.entries(api.getElements(types.NOTES_ELEMENT)).reduce((acc, [k, v]) => ({ ...acc, [k]: v.render }), {});
-    const options = { ...defaultOptions, overrides: { ...defaultOptions.overrides, ...extraElements } };
+    const options = {
+      ...defaultOptions,
+      overrides: { ...defaultOptions.overrides, ...extraElements },
+    };
 
     return value ? (
       <Panel className="addon-notes-container">
-      <DocumentFormatting>
-        <Markdown options={options}>{value}</Markdown>
+        <DocumentFormatting>
+          <Markdown options={options}>{value}</Markdown>
         </DocumentFormatting>
       </Panel>
     ) : (
       <Placeholder>
+        <React.Fragment>No notes yet</React.Fragment>
         <React.Fragment>
-          No notes yet
-        </React.Fragment>
-        <React.Fragment>
-          Learn how to <Link href="https://github.com/storybooks/storybook/tree/master/addons/notes" target="_blank" withArrow>document components in Markdown</Link>
+          Learn how to{' '}
+          <Link href="https://github.com/storybooks/storybook/tree/master/addons/notes" target="_blank" withArrow>
+            document components in Markdown
+          </Link>
         </React.Fragment>
       </Placeholder>
     );


### PR DESCRIPTION
Issue: #5726

## What I did
- SyntaxHighlighter component (in notes/src/Panel.tsx) should return the inline code as it is
- include required language propto SyntaxHighlighterBase
- styling fixes

## How to test
include an inline code in a markdown file.
- Is this testable with Jest or Chromatic screenshots? yep
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

If your answer is yes to any of these, please make sure to include it in your PR.
